### PR TITLE
fix: take the LeafIndex changes from mmr and use it

### DIFF
--- a/completeness/go.mod
+++ b/completeness/go.mod
@@ -26,8 +26,8 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/datatrails/go-datatrails-common-api-gen v0.4.8 // indirect
-	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7 // indirect
-	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1 // indirect
+	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9 // indirect
+	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2 // indirect
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1 // indirect
 	github.com/datatrails/go-datatrails-simplehash v0.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/completeness/go.sum
+++ b/completeness/go.sum
@@ -47,10 +47,10 @@ github.com/datatrails/go-datatrails-common-api-gen v0.4.8 h1:IzrhGHi9TyEASjk06Qj
 github.com/datatrails/go-datatrails-common-api-gen v0.4.8/go.mod h1:zlwFPJXYAK7yqgLtxKUgkF5gw9ddxoqWS+Ruhf+Ksw0=
 github.com/datatrails/go-datatrails-demos/logverification v0.0.3 h1:P8DU8ZSVqOmMkm37LWhxpWXrBPwhExuGSXpJ+306LyE=
 github.com/datatrails/go-datatrails-demos/logverification v0.0.3/go.mod h1:5uMSYrfH8l3RNtiu934BXhwym9TorhSp375O188MJrM=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7 h1:844V2QxLhVmSkOISu00qHMxs4+XpGU2tHQ433S3akHY=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7/go.mod h1:eNMW+ZfyGT4ttj/vAE56Ut1uWfdc9zW1W7yIIl2XF1k=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1 h1:XggMVejsJ72cAL/msjPhQUSQNeElSh/O1zZcvX4d4JU=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9 h1:89ma+ZM2UllHdBGOzjye8MXiizpJWZbCthhESyO84tY=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9/go.mod h1:5o8k+btUoxenGw9sy7x85q2qdzsmu9v2ALMk13RTpG4=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2 h1:Jxov4/onoFiCISLQNSPy/nyt3USAEvUZpEjlScHJYKI=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1 h1:sIyXWKTadqmVEsPj66RlKwRKzNQ7hK9SH1fRjZFDCa8=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1/go.mod h1:KGdkOtamWG48EN4AXtTHPv6C0jJKrj840IMSkrD+egk=
 github.com/datatrails/go-datatrails-simplehash v0.0.3 h1:H4zNsdB9d2KMZ3EqM6n6AMGYB/RquEjANqcNrUlZtp8=

--- a/integrity/go.mod
+++ b/integrity/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/datatrails/go-datatrails-common-api-gen v0.4.8 // indirect
-	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7 // indirect
-	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1 // indirect
+	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9 // indirect
+	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2 // indirect
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1 // indirect
 	github.com/datatrails/go-datatrails-simplehash v0.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/integrity/go.sum
+++ b/integrity/go.sum
@@ -47,10 +47,10 @@ github.com/datatrails/go-datatrails-common-api-gen v0.4.8 h1:IzrhGHi9TyEASjk06Qj
 github.com/datatrails/go-datatrails-common-api-gen v0.4.8/go.mod h1:zlwFPJXYAK7yqgLtxKUgkF5gw9ddxoqWS+Ruhf+Ksw0=
 github.com/datatrails/go-datatrails-demos/logverification v0.0.3 h1:P8DU8ZSVqOmMkm37LWhxpWXrBPwhExuGSXpJ+306LyE=
 github.com/datatrails/go-datatrails-demos/logverification v0.0.3/go.mod h1:5uMSYrfH8l3RNtiu934BXhwym9TorhSp375O188MJrM=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7 h1:844V2QxLhVmSkOISu00qHMxs4+XpGU2tHQ433S3akHY=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7/go.mod h1:eNMW+ZfyGT4ttj/vAE56Ut1uWfdc9zW1W7yIIl2XF1k=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1 h1:XggMVejsJ72cAL/msjPhQUSQNeElSh/O1zZcvX4d4JU=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9 h1:89ma+ZM2UllHdBGOzjye8MXiizpJWZbCthhESyO84tY=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9/go.mod h1:5o8k+btUoxenGw9sy7x85q2qdzsmu9v2ALMk13RTpG4=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2 h1:Jxov4/onoFiCISLQNSPy/nyt3USAEvUZpEjlScHJYKI=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1 h1:sIyXWKTadqmVEsPj66RlKwRKzNQ7hK9SH1fRjZFDCa8=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1/go.mod h1:KGdkOtamWG48EN4AXtTHPv6C0jJKrj840IMSkrD+egk=
 github.com/datatrails/go-datatrails-simplehash v0.0.3 h1:H4zNsdB9d2KMZ3EqM6n6AMGYB/RquEjANqcNrUlZtp8=

--- a/logverification/go.mod
+++ b/logverification/go.mod
@@ -5,8 +5,8 @@ go 1.22
 require (
 	github.com/datatrails/go-datatrails-common v0.16.1
 	github.com/datatrails/go-datatrails-common-api-gen v0.4.5
-	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7
-	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1
+	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9
+	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2
 	github.com/datatrails/go-datatrails-simplehash v0.0.3
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/protobuf v1.34.1

--- a/logverification/go.sum
+++ b/logverification/go.sum
@@ -45,10 +45,10 @@ github.com/datatrails/go-datatrails-common v0.16.1 h1:kaNOwyu8EmBbIR44daWDiUZxBt
 github.com/datatrails/go-datatrails-common v0.16.1/go.mod h1:IEcuwUaFl+bI1tt30r+Ov2+nvpcAZH/kXmAPGFjkwT4=
 github.com/datatrails/go-datatrails-common-api-gen v0.4.5 h1:QtxIFSdOEf6bhHZd7g/MfWdCWfPEtwTQNDz3K9u33+c=
 github.com/datatrails/go-datatrails-common-api-gen v0.4.5/go.mod h1:OQN91xvlW6xcWTFvwsM2Nn4PZwFAIOE52FG7yRl4QPQ=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7 h1:844V2QxLhVmSkOISu00qHMxs4+XpGU2tHQ433S3akHY=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.7/go.mod h1:eNMW+ZfyGT4ttj/vAE56Ut1uWfdc9zW1W7yIIl2XF1k=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1 h1:XggMVejsJ72cAL/msjPhQUSQNeElSh/O1zZcvX4d4JU=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9 h1:89ma+ZM2UllHdBGOzjye8MXiizpJWZbCthhESyO84tY=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9/go.mod h1:5o8k+btUoxenGw9sy7x85q2qdzsmu9v2ALMk13RTpG4=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2 h1:Jxov4/onoFiCISLQNSPy/nyt3USAEvUZpEjlScHJYKI=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1 h1:sIyXWKTadqmVEsPj66RlKwRKzNQ7hK9SH1fRjZFDCa8=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1/go.mod h1:KGdkOtamWG48EN4AXtTHPv6C0jJKrj840IMSkrD+egk=
 github.com/datatrails/go-datatrails-simplehash v0.0.3 h1:H4zNsdB9d2KMZ3EqM6n6AMGYB/RquEjANqcNrUlZtp8=

--- a/logverification/leafrange.go
+++ b/logverification/leafrange.go
@@ -15,10 +15,10 @@ import "github.com/datatrails/go-datatrails-merklelog/mmr"
 func LeafRange(sortedEvents []EventDetails) (uint64, uint64) {
 
 	lowerBoundMMRIndex := sortedEvents[0].MerkleLog.Commit.Index
-	lowerBoundLeafIndex := mmr.LeafCount(lowerBoundMMRIndex+1) - 1 // Note: LeafCount takes an mmrIndex here not a size
+	lowerBoundLeafIndex := mmr.LeafIndex(lowerBoundMMRIndex)
 
 	upperBoundMMRIndex := sortedEvents[len(sortedEvents)-1].MerkleLog.Commit.Index
-	upperBoundLeafIndex := mmr.LeafCount(upperBoundMMRIndex+1) - 1 // Note: LeafCount takes an mmrIndex here not a size
+	upperBoundLeafIndex := mmr.LeafIndex(upperBoundMMRIndex)
 
 	return lowerBoundLeafIndex, upperBoundLeafIndex
 


### PR DESCRIPTION
AB#9551

unit test and demo output:

banks:go-datatrails-demos robin$ ta test:unit
{"type":"run_test","name":"TestMain"}
{"type":"end_test","name":"TestMain","result":"PASS"}
{"type":"status","result":"PASS"}
{"type":"output","data":"coverage: [no statements]"}
{"type":"summary","name":"github.com/datatrails/go-datatrails-demos/consistency","result":"ok","duration":1226000000}
{"type":"run_test","name":"TestCompletenessDemo"}
{"type":"end_test","name":"TestCompletenessDemo","result":"PASS","duration":500000000}
{"type":"status","result":"PASS"}
{"type":"coverage","coverage_percentage":30.8}
{"type":"summary","name":"github.com/datatrails/go-datatrails-demos/completeness","result":"ok","duration":1749000000,"coverage_percentage":30.8}
{"type":"run_test","name":"TestIntegrityDemo"}
{"type":"end_test","name":"TestIntegrityDemo","result":"PASS","duration":420000000}
{"type":"status","result":"PASS"}
{"type":"coverage","coverage_percentage":44.4}
{"type":"summary","name":"github.com/datatrails/go-datatrails-demos/integrity","result":"ok","duration":1670000000,"coverage_percentage":44.4}
{"type":"run_test","name":"TestLogVersion0Hash"}
{"type":"run_test","name":"TestLogVersion0Hash/positive_(kat)"}
{"type":"end_test","name":"TestLogVersion0Hash","result":"PASS"}
{"type":"end_test","name":"TestLogVersion0Hash/positive_(kat)","result":"PASS","indent":1}
{"type":"status","result":"PASS"}
{"type":"coverage","coverage_percentage":5.9}
{"type":"summary","name":"github.com/datatrails/go-datatrails-demos/logverification","result":"ok","duration":1238000000,"coverage_percentage":5.9}
banks:go-datatrails-demos robin$ ta demos:integrity

Event included on merkle log: true
banks:go-datatrails-demos robin$ ta demos:completeness
Complete List of events included on merkle log